### PR TITLE
replace github action bot with liquibot

### DIFF
--- a/.github/workflows/pull-request-labeled-closed.yml
+++ b/.github/workflows/pull-request-labeled-closed.yml
@@ -131,4 +131,4 @@ jobs:
           mvn versions:set -DnextSnapshot=true
           git add pom.xml
           git commit -m "Version Bumped to Snapshot for Developent"
-          git push "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.base_ref }}
+          git push "https://liquibot:${{ secrets.BOT_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.event.pull_request.head.ref }} --follow-tags --tags

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,7 +78,7 @@ jobs:
           git add pom.xml
           git commit -m "Version Bumped to $VERSION_TAG"
           git tag -a -m "Version Bumped to $VERSION_TAG" liquibase-postgresql-$VERSION_TAG
-          git push "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.event.pull_request.head.ref }} --follow-tags --tags
+          git push "https://liquibot:${{ secrets.BOT_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.event.pull_request.head.ref }} --follow-tags --tags
 
       - run: ./.github/add-label-to-pull-request.sh
         env:


### PR DESCRIPTION
#49 has a permission issue during automation for github-actio[bot]. As a solution, liquibot has been explicitly added to the [liquibase org members](https://github.com/orgs/liquibase/people) and a new token has been added with proper permissions. This token replaces the default github action bot token in two places.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1595) by [Unito](https://www.unito.io)
