### PR TITLE
fix(ci): grant actions:read so release can resolve build-logic ref (TECHOPS-609)

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
+  actions: read # required by "Get build-logic ref" to query the Actions API (TECHOPS-609)
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

Releasing this extension fails at startup with "This run likely failed because of a workflow file issue" (`startup_failure`).

## Root cause

The reusable workflow `liquibase/build-logic/.github/workflows/extension-release-published.yml` requests the `actions: read` scope for its "Get build-logic ref" step (it queries the Actions API to resolve which build-logic ref to check out). Reusable-workflow permissions can only be reduced, not elevated, above the caller. This caller's `permissions:` block omitted `actions:`, so the requested scope exceeded the caller ceiling and GitHub rejected the run before it started.

## Fix

Add `actions: read` to the caller's `permissions:` block so it matches the scope the reusable workflow needs.

Ref: TECHOPS-609

🤖 Generated with [Claude Code](https://claude.com/claude-code)